### PR TITLE
[Composer] Set the version of behat/mink-bundle to a stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "behat/mink-selenium2-driver": "*",
         "behat/symfony2-extension": "*",
         "behat/common-contexts": "1.2.*@dev",
-        "behat/mink-bundle": "dev-master",
+        "behat/mink-bundle": "1.4.*",
         "phpspec/phpspec": "2.0.*@dev"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -3,7 +3,7 @@
         "This file locks the dependencies of your project to a known state",
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
     ],
-    "hash": "d1814f7e19cb77056bad29decc42e9f9",
+    "hash": "d47e746af7d58e73d22e2b8aeac483e4",
     "packages": [
         {
             "name": "behat/behat",
@@ -313,7 +313,7 @@
         },
         {
             "name": "behat/mink-bundle",
-            "version": "dev-master",
+            "version": "v1.4.1",
             "target-dir": "Behat/MinkBundle",
             "source": {
                 "type": "git",
@@ -1743,7 +1743,6 @@
     "stability-flags": {
         "behat/behat": 20,
         "behat/common-contexts": 20,
-        "behat/mink-bundle": 20,
         "phpspec/phpspec": 20
     },
     "platform": {


### PR DESCRIPTION
@catchamonkey 

Required to keep the minimum-stability flag to stable in our projects.

Otherwise it's necessary to require explicitly all the dependencies that uses dev-master in the main composer.json.

Like so

```
"require-dev": {
        "infinitytracking/test-bundle": "0.1.0",
        "behat/mink-bundle": "dev-master@dev"    <-- this is a dependecy of test-bundle, but must be forced in the root composer 
    },
```
