### PR TITLE
[phpunit] Upgrades phpunit to version 4 and adds some changes to the code to use feature available in this version

### DIFF
--- a/Test/BaseTestCase.php
+++ b/Test/BaseTestCase.php
@@ -8,4 +8,10 @@ use Infinity\Bundle\TestBundle\Test\Selenium2\Selenium2Trait;
 class BaseTestCase extends MinkTestCase
 {
     use Selenium2Trait;
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->getScreenshotOnFailure();
+    }
 }

--- a/Test/DBTestCase.php
+++ b/Test/DBTestCase.php
@@ -7,4 +7,16 @@ use Infinity\Bundle\TestBundle\Test\Doctrine\DoctrineTrait;
 class DBTestCase extends BaseTestCase
 {
     use DoctrineTrait;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->setUpDatabase();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        $this->tearDownDatabase();
+    }
 }

--- a/Test/Doctrine/DoctrineTrait.php
+++ b/Test/Doctrine/DoctrineTrait.php
@@ -13,18 +13,12 @@ use Infinity\Bundle\TestBundle\Test\Helper\DatabaseHelper;
  */
 trait DoctrineTrait
 {
-    /**
-     * @before
-     */
     public function setUpDatabase()
     {
         $helper = new DatabaseHelper($this->getKernel());
         $helper->setUpDatabase();
     }
 
-    /**
-     * @after
-     */
     public function tearDownDatabase()
     {
         $helper = new DatabaseHelper($this->getKernel());

--- a/Test/Selenium2/Selenium2Trait.php
+++ b/Test/Selenium2/Selenium2Trait.php
@@ -13,9 +13,6 @@ use Infinity\Bundle\TestBundle\Test\Helper\ScreenshotHelper;
  */
 trait Selenium2Trait
 {
-    /**
-     * @after
-     */
     public function getScreenshotOnFailure()
     {
         $mink = $this->getMink();


### PR DESCRIPTION
@catchamonkey

Apparently we're next to be able to get rid of phpunit 3.7. We were stuck there before because of the dependencies of some behat's contexts.

Problem that is about to be solved here https://github.com/Behat/CommonContexts/pull/56.
We weren't using the specific context which have this dependency so we can move forward.
I decided to move conservatively before just to stay inline with behat, even if we were forced to have a very inelegant solution that relied on calling parent::setup and parent::teardown all over.
I've updated also that part. 
